### PR TITLE
Fix error when localStorage is not supported

### DIFF
--- a/src/kappa.js
+++ b/src/kappa.js
@@ -5,7 +5,11 @@
   /**
    * Check for previous data in localStorage
    */
-  let previousStorage = localStorage.getItem('kappa-js');
+  try {
+    let previousStorage = localStorage.getItem('kappa-js');
+  } catch (e) {
+    let previousStorage = null;
+  }
 
   /**
    * Initialize KappaJS
@@ -28,7 +32,7 @@
   function getTwitchEmotesPromise(res, rej) {
     $.get('https://twitchemotes.com/api_cache/v2/global.json',
       (data) => {
-        if(typeof Storage !== 'undefined')
+        if(typeof Storage !== 'undefined' && previousStorage !== null)
           localStorage.setItem('kappa-js', JSON.stringify(data));
 
         res(data);


### PR DESCRIPTION
An uncaught exception occurred when I using Kappa.js in the WebView at [Twitch Android Aplication](https://play.google.com/store/apps/details?id=tv.twitch.android.app), and this is the uncaught exception:
```
Uncaught TypeError: Cannot read property 'getItem' of null 
  source: Kappa.js/dist/kappa.js
  lineno: 10
  colno: 37
```

and here's the code where the error occurs:
```
let previousStorage = localStorage.getItem('kappa-js');
//                                 ^^^^^^^ here
```

After debugging it became clear that this error occurs when `localStorage` is `null`. It seems that Twitch app did not turn `setDomStorageEnabled` to `true`. [Since we cannot set that value manually,](http://stackoverflow.com/questions/5899087/android-webview-localstorage/5934650#5934650) I modified some code so there's no `localStorage` when it's not working properly.

Please let me know if there's something wrong, or a better way to solve this issue.